### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            libadwaita-1-dev \
+            libatspi2.0-dev \
+            libgirepository1.0-dev \
+            libglib2.0-dev \
+            libgtk-4-dev \
+            libgtk4-layer-shell-dev \
+            libvulkan-dev \
+            libxkbcommon-dev \
+            pkg-config \
+            tesseract-ocr
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Lint with clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test


### PR DESCRIPTION
## Summary

Adds a minimal GitHub Actions CI workflow that runs on push to main and on pull requests. Catches formatting, lint, and test regressions automatically.

## Changes

New file: `.github/workflows/ci.yml`

Steps run in order:
1. Install system dependencies (libadwaita, libgtk4, etc. from the README)
2. Set up stable Rust with clippy and rustfmt
3. `cargo fmt --check`
4. `cargo clippy -- -D warnings`
5. `cargo test`

Single job, no matrix, no caching. Kept deliberately minimal so you can customize to taste.

## Testing

Workflow syntax validated. System deps match the Ubuntu section of the README.

Feel free to adjust the triggers, add caching, or remove steps that don't fit your workflow.

This contribution was developed with AI assistance (Codex).