### PR TITLE
feat(history): add 'Purge History' button with privacy-focused cleanup

### DIFF
--- a/app/src/history_store.rs
+++ b/app/src/history_store.rs
@@ -9,8 +9,43 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::transcript_log::{TranscriptEntry, TranscriptLog};
 
 const HISTORY_DIR_NAME: &str = "history";
+const RECORDINGS_DIR_NAME: &str = "recordings";
 const ARCHIVE_METADATA_FILE_NAME: &str = "run.json";
 const ARCHIVED_SOURCE_WAV_FILE_NAME: &str = "source.wav";
+
+/// Result of a privacy purge of history / recording artifacts.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HistoryPurgeStats {
+    pub deleted_files: usize,
+    pub deleted_dirs: usize,
+    pub freed_bytes: u64,
+    pub errors: usize,
+}
+
+impl HistoryPurgeStats {
+    pub fn summary_text(&self) -> String {
+        if self.deleted_files == 0 && self.deleted_dirs == 0 && self.errors == 0 {
+            return "No history or recordings to purge.".into();
+        }
+        let mb = self.freed_bytes as f64 / (1024.0 * 1024.0);
+        if self.errors == 0 {
+            format!(
+                "Purged history ({} file(s), {} folder(s)), freed {:.1} MB.",
+                self.deleted_files, self.deleted_dirs, mb
+            )
+        } else {
+            format!(
+                "Purged history ({} file(s), {} folder(s)), freed {:.1} MB ({} error(s)).",
+                self.deleted_files, self.deleted_dirs, mb, self.errors
+            )
+        }
+    }
+}
+
+/// Kept for older call sites / tests that still use the previous name.
+pub type RecordingPurgeStats = HistoryPurgeStats;
+
+const TRANSCRIPT_LOG_FILE_NAME: &str = "transcript-log.jsonl";
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArchiveWriteRequest {
@@ -249,6 +284,118 @@ impl HistoryStore {
             .collect())
     }
 
+    /// Privacy purge: remove past dictation history and recording artifacts that
+    /// are not required for Pepper X to keep working.
+    ///
+    /// Deletes:
+    /// - `history/run-*` directories (WAV + `run.json` transcripts/OCR/context)
+    /// - `transcript-log.jsonl`
+    /// - Pepper X captures in `recordings/` (`live-recording-*.wav`, `test-dictation-*.wav`)
+    ///
+    /// Keeps settings, setup/onboarding, correction memory, models, and any
+    /// non-Pepper files under a user-managed recordings directory.
+    pub fn purge_history_for_privacy(&self) -> io::Result<HistoryPurgeStats> {
+        let mut stats = HistoryPurgeStats::default();
+
+        self.purge_pepperx_recording_files(&mut stats);
+        self.purge_history_run_dirs(&mut stats);
+        self.purge_transcript_log(&mut stats);
+
+        // Keep an empty history root so subsequent archive_run/open stay valid.
+        if let Err(error) = fs::create_dir_all(&self.history_root) {
+            let _ = error;
+            stats.errors += 1;
+        }
+
+        Ok(stats)
+    }
+
+    /// Alias kept for older call sites.
+    pub fn purge_recording_audio(&self) -> io::Result<HistoryPurgeStats> {
+        self.purge_history_for_privacy()
+    }
+
+    fn purge_pepperx_recording_files(&self, stats: &mut HistoryPurgeStats) {
+        let recordings_dir = self.root.join(RECORDINGS_DIR_NAME);
+        if !recordings_dir.is_dir() {
+            return;
+        }
+        let entries = match fs::read_dir(&recordings_dir) {
+            Ok(entries) => entries,
+            Err(_) => {
+                stats.errors += 1;
+                return;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !is_pepperx_recording_filename(name) {
+                continue;
+            }
+            match remove_file_with_size(&path) {
+                Ok(bytes) => {
+                    stats.deleted_files += 1;
+                    stats.freed_bytes += bytes;
+                }
+                Err(_) => stats.errors += 1,
+            }
+        }
+    }
+
+    fn purge_history_run_dirs(&self, stats: &mut HistoryPurgeStats) {
+        if !self.history_root.is_dir() {
+            return;
+        }
+        let entries = match fs::read_dir(&self.history_root) {
+            Ok(entries) => entries,
+            Err(_) => {
+                stats.errors += 1;
+                return;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                match remove_dir_all_with_size(&path) {
+                    Ok((files, bytes)) => {
+                        stats.deleted_dirs += 1;
+                        stats.deleted_files += files;
+                        stats.freed_bytes += bytes;
+                    }
+                    Err(_) => stats.errors += 1,
+                }
+            } else if path.is_file() {
+                match remove_file_with_size(&path) {
+                    Ok(bytes) => {
+                        stats.deleted_files += 1;
+                        stats.freed_bytes += bytes;
+                    }
+                    Err(_) => stats.errors += 1,
+                }
+            }
+        }
+    }
+
+    fn purge_transcript_log(&self, stats: &mut HistoryPurgeStats) {
+        let log_path = self.root.join(TRANSCRIPT_LOG_FILE_NAME);
+        if !log_path.is_file() {
+            return;
+        }
+        match remove_file_with_size(&log_path) {
+            Ok(bytes) => {
+                stats.deleted_files += 1;
+                stats.freed_bytes += bytes;
+            }
+            Err(_) => stats.errors += 1,
+        }
+    }
+
     fn legacy_runs(&self) -> io::Result<Vec<ArchivedRun>> {
         Ok(self
             .legacy_log
@@ -324,6 +471,48 @@ fn archive_source_wav(source_wav_path: &Path, run_dir: &Path) -> Option<io::Resu
             .map(|_| archived_source_wav_path)
             .map_err(io::Error::from),
     )
+}
+
+fn is_pepperx_recording_filename(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower.ends_with(".wav")
+        && (lower.starts_with("live-recording-") || lower.starts_with("test-dictation-"))
+}
+
+fn remove_file_with_size(path: &Path) -> io::Result<u64> {
+    let size = fs::metadata(path).map(|meta| meta.len()).unwrap_or(0);
+    fs::remove_file(path)?;
+    Ok(size)
+}
+
+fn remove_dir_all_with_size(path: &Path) -> io::Result<(usize, u64)> {
+    let (files, bytes) = dir_tree_stats(path)?;
+    fs::remove_dir_all(path)?;
+    Ok((files, bytes))
+}
+
+fn dir_tree_stats(path: &Path) -> io::Result<(usize, u64)> {
+    let mut files = 0usize;
+    let mut bytes = 0u64;
+    if path.is_file() {
+        return Ok((1, fs::metadata(path).map(|meta| meta.len()).unwrap_or(0)));
+    }
+    if !path.is_dir() {
+        return Ok((0, 0));
+    }
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let child = entry.path();
+        if child.is_dir() {
+            let (child_files, child_bytes) = dir_tree_stats(&child)?;
+            files += child_files;
+            bytes += child_bytes;
+        } else if child.is_file() {
+            files += 1;
+            bytes += fs::metadata(&child).map(|meta| meta.len()).unwrap_or(0);
+        }
+    }
+    Ok((files, bytes))
 }
 
 fn next_run_id() -> String {
@@ -507,5 +696,71 @@ mod history_store_tests {
         assert_eq!(reloaded_child.run_id, child.run_id);
         assert_eq!(reloaded_child.parent_run_id, Some(parent.run_id));
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn purge_history_for_privacy_wipes_runs_log_and_wavs_keeps_settings_surface() {
+        let root = temp_root("purge-privacy");
+        std::fs::create_dir_all(&root).unwrap();
+        let source_wav_path = root.join("source.wav");
+        std::fs::write(&source_wav_path, b"pepper-x-audio-payload").unwrap();
+        let settings_path = root.join("settings.json");
+        let setup_path = root.join("setup.json");
+        let corrections_dir = root.join("corrections");
+        std::fs::write(&settings_path, b"{\"keep\":true}").unwrap();
+        std::fs::write(&setup_path, b"{\"keep\":true}").unwrap();
+        std::fs::create_dir_all(&corrections_dir).unwrap();
+        std::fs::write(corrections_dir.join("corrections.jsonl"), b"keep").unwrap();
+
+        let store = HistoryStore::open(&root).expect("history store should open");
+        let archived = store
+            .archive_run(&ArchiveWriteRequest::new(transcript_entry(&source_wav_path)))
+            .expect("archive write should succeed");
+        assert!(archived.metadata_path.is_file());
+        assert!(root.join("transcript-log.jsonl").is_file());
+
+        let recordings_dir = root.join("recordings");
+        std::fs::create_dir_all(&recordings_dir).unwrap();
+        let live = recordings_dir.join("live-recording-1-2.wav");
+        let test_dictation = recordings_dir.join("test-dictation-99.wav");
+        let keep_user_file = recordings_dir.join("Sean-notes.flac");
+        let keep_other_wav = recordings_dir.join("meeting-notes.wav");
+        std::fs::write(&live, b"live-wav").unwrap();
+        std::fs::write(&test_dictation, b"test-wav").unwrap();
+        std::fs::write(&keep_user_file, b"user-flac").unwrap();
+        std::fs::write(&keep_other_wav, b"other-wav").unwrap();
+
+        let stats = store
+            .purge_history_for_privacy()
+            .expect("purge should succeed");
+
+        assert!(stats.deleted_files >= 4);
+        assert_eq!(stats.deleted_dirs, 1);
+        assert!(stats.freed_bytes > 0);
+        assert_eq!(stats.errors, 0);
+        assert!(!live.exists());
+        assert!(!test_dictation.exists());
+        assert!(keep_user_file.is_file());
+        assert!(keep_other_wav.is_file());
+        assert!(!archived.run_dir.exists());
+        assert!(!root.join("transcript-log.jsonl").exists());
+        assert!(root.join("history").is_dir());
+        assert!(store.recent_runs().expect("reload history").is_empty());
+        assert!(settings_path.is_file());
+        assert!(setup_path.is_file());
+        assert!(corrections_dir.join("corrections.jsonl").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn is_pepperx_recording_filename_matches_live_and_test_only() {
+        assert!(is_pepperx_recording_filename(
+            "live-recording-103408-1784193243847383261.wav"
+        ));
+        assert!(is_pepperx_recording_filename("test-dictation-1.wav"));
+        assert!(is_pepperx_recording_filename("LIVE-RECORDING-x.WAV"));
+        assert!(!is_pepperx_recording_filename("meeting-notes.wav"));
+        assert!(!is_pepperx_recording_filename("live-recording-x.flac"));
+        assert!(!is_pepperx_recording_filename("source.wav"));
     }
 }

--- a/app/src/history_view.rs
+++ b/app/src/history_view.rs
@@ -6,9 +6,9 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use crate::history_store::ArchivedRun;
+use crate::history_store::{ArchivedRun, HistoryStore};
 use crate::settings::AppSettings;
-use crate::transcript_log::{DiarizationSummary, TranscriptEntry};
+use crate::transcript_log::{state_root, DiarizationSummary, TranscriptEntry};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct HistoryBrowserModel {
@@ -51,6 +51,11 @@ impl HistoryBrowserModel {
         };
         self.selected_index = index;
         true
+    }
+
+    pub(crate) fn clear_runs(&mut self) {
+        self.runs.clear();
+        self.selected_index = 0;
     }
 
     pub(crate) fn rerunnable_run_id(&self) -> Option<&str> {
@@ -146,9 +151,30 @@ pub(crate) fn build_history_browser(
     rerun_archived_run: Option<Rc<dyn Fn(String, String) -> Option<TranscriptEntry>>>,
     rerun_cleanup: Option<Rc<dyn Fn(String, String, Option<String>) -> Option<TranscriptEntry>>>,
     play_audio: Option<Rc<dyn Fn(PathBuf)>>,
-) -> gtk::Paned {
+) -> gtk::Box {
     let model = Rc::new(RefCell::new(HistoryBrowserModel::new(runs.to_vec())));
     let settings = AppSettings::load_or_default();
+
+    // --- Toolbar: privacy purge (status left, button right) ---
+    let toolbar = gtk::Box::new(Orientation::Horizontal, 12);
+    toolbar.set_margin_top(12);
+    toolbar.set_margin_bottom(6);
+    toolbar.set_margin_start(12);
+    toolbar.set_margin_end(12);
+    let purge_status = gtk::Label::builder()
+        .label("")
+        .xalign(0.0)
+        .hexpand(true)
+        .wrap(true)
+        .css_classes(["dim-label", "caption"])
+        .build();
+    let purge_button = gtk::Button::builder()
+        .label("Purge history")
+        .css_classes(["destructive-action"])
+        .halign(Align::End)
+        .build();
+    toolbar.append(&purge_status);
+    toolbar.append(&purge_button);
 
     // --- Left side: run list ---
     let list_box = gtk::ListBox::builder()
@@ -577,11 +603,112 @@ pub(crate) fn build_history_browser(
     }
 
     // =====================================================================
+    // Privacy purge: history + associated recording artifacts
+    // =====================================================================
+    {
+        let model = model.clone();
+        let list_box = list_box.clone();
+        let play_button = play_button.clone();
+        let rerun_button = rerun_button.clone();
+        let rerun_cleanup_button = rerun_cleanup_button.clone();
+        let purge_status = purge_status.clone();
+        let metadata_line = metadata_line.clone();
+        let transcription_subtitle = transcription_subtitle.clone();
+        let original_raw_label = original_raw_card.1.clone();
+        let cleanup_subtitle = cleanup_subtitle.clone();
+        let original_cleaned_label = original_cleaned_card.1.clone();
+        let diarization_container = diarization_container.clone();
+        let use_ocr_check = use_ocr_check.clone();
+        let rerun_raw_card_frame = rerun_raw_card.0.clone();
+        let rerun_cleaned_card_frame = rerun_cleaned_card.0.clone();
+        let cleanup_timing_label = cleanup_timing_label.clone();
+        purge_button.connect_clicked(move |button| {
+            let parent = button
+                .root()
+                .and_then(|root| root.downcast::<gtk::Window>().ok());
+            let dialog = adw::AlertDialog::new(
+                Some("Purge history?"),
+                Some(
+                    "Permanently deletes past dictation history for privacy:\n\
+                     • archived runs (transcripts, OCR, context, WAV)\n\
+                     • transcript log\n\
+                     • Pepper X live/test recordings (live-recording-*, test-dictation-*)\n\n\
+                     Keeps settings, models, and correction memory.\n\
+                     Other files in a user-managed recordings folder are left alone.\n\
+                     This cannot be undone.",
+                ),
+            );
+            dialog.add_response("cancel", "Cancel");
+            dialog.add_response("purge", "Purge");
+            dialog.set_response_appearance("purge", adw::ResponseAppearance::Destructive);
+            dialog.set_default_response(Some("cancel"));
+            dialog.set_close_response("cancel");
+
+            let model = model.clone();
+            let list_box = list_box.clone();
+            let play_button = play_button.clone();
+            let rerun_button = rerun_button.clone();
+            let rerun_cleanup_button = rerun_cleanup_button.clone();
+            let purge_status = purge_status.clone();
+            let metadata_line = metadata_line.clone();
+            let transcription_subtitle = transcription_subtitle.clone();
+            let original_raw_label = original_raw_label.clone();
+            let cleanup_subtitle = cleanup_subtitle.clone();
+            let original_cleaned_label = original_cleaned_label.clone();
+            let diarization_container = diarization_container.clone();
+            let use_ocr_check = use_ocr_check.clone();
+            let rerun_raw_card_frame = rerun_raw_card_frame.clone();
+            let rerun_cleaned_card_frame = rerun_cleaned_card_frame.clone();
+            let cleanup_timing_label = cleanup_timing_label.clone();
+            dialog.connect_response(None, move |_, response| {
+                if response != "purge" {
+                    return;
+                }
+                match HistoryStore::open(state_root())
+                    .and_then(|store| store.purge_history_for_privacy())
+                {
+                    Ok(stats) => {
+                        purge_status.set_label(&stats.summary_text());
+                        model.borrow_mut().clear_runs();
+                        while let Some(child) = list_box.first_child() {
+                            list_box.remove(&child);
+                        }
+                        metadata_line.set_label("");
+                        transcription_subtitle.set_label("");
+                        original_raw_label.set_label("No archived runs yet.");
+                        cleanup_subtitle.set_label("");
+                        original_cleaned_label.set_label("No cleanup transcript for this run.");
+                        clear_diarization_container(&diarization_container);
+                        use_ocr_check.set_visible(false);
+                        rerun_raw_card_frame.set_visible(false);
+                        rerun_cleaned_card_frame.set_visible(false);
+                        cleanup_timing_label.set_visible(false);
+                        play_button.set_sensitive(false);
+                        rerun_button.set_sensitive(false);
+                        rerun_cleanup_button.set_sensitive(false);
+                    }
+                    Err(error) => {
+                        purge_status.set_label(&format!("Purge failed: {error}"));
+                    }
+                }
+            });
+
+            if let Some(parent) = parent.as_ref() {
+                dialog.present(Some(parent));
+            } else {
+                dialog.present(None::<&gtk::Window>);
+            }
+        });
+    }
+
+    // =====================================================================
     // Paned: list on left, scrollable detail on right
     // =====================================================================
     let details_scroll = gtk::ScrolledWindow::new();
     details_scroll.set_policy(PolicyType::Never, PolicyType::Automatic);
     details_scroll.set_child(Some(&details_box));
+    details_scroll.set_hexpand(true);
+    details_scroll.set_vexpand(true);
 
     let list_scroll = gtk::ScrolledWindow::new();
     list_scroll.set_min_content_width(280);
@@ -591,9 +718,17 @@ pub(crate) fn build_history_browser(
     let browser = gtk::Paned::new(Orientation::Horizontal);
     browser.set_wide_handle(true);
     browser.set_position(300);
+    browser.set_hexpand(true);
+    browser.set_vexpand(true);
     browser.set_start_child(Some(&list_scroll));
     browser.set_end_child(Some(&details_scroll));
-    browser
+
+    let root = gtk::Box::new(Orientation::Vertical, 0);
+    root.set_hexpand(true);
+    root.set_vexpand(true);
+    root.append(&toolbar);
+    root.append(&browser);
+    root
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- New 'Purge History' button (top-right in History tab)
- Deletes:
  - All run-* folders (WAV + run.json with transcripts, OCR, timings, etc.)
  - transcript-log.jsonl
  - recordings/live-recording-*.wav
  - recordings/test-dictation-*.wav
- Preserves:
  - settings.json, setup.json, onboarding state
  - corrections/ folder (user corrections memory)
  - Downloaded models
  - Non-Pepper files in recordings/ (user symlinks, etc.)
- Shows clear confirmation dialog emphasizing privacy
- Refreshes history list after purge